### PR TITLE
Extract queue management logic to dedicated script

### DIFF
--- a/RadioQ10/wwwroot/index.html
+++ b/RadioQ10/wwwroot/index.html
@@ -254,6 +254,7 @@
         </div>
     </div>
 
+    <script src="js/queueManager.js"></script>
     <script src="js/app.js"></script>
     <script src="js/buttonControls.js"></script>
 </body>

--- a/RadioQ10/wwwroot/js/app.js
+++ b/RadioQ10/wwwroot/js/app.js
@@ -8,180 +8,24 @@ let playerA;
 let isSyncing = false; // evita loops de eventos
 let playerReady = false;
 let pendingSync = null;
-let currentQueueItemId = null;
-let isHandlingQueueEnd = false;
-
-const queueListEl = document.getElementById('queueList');
-const queueStatusEl = document.getElementById('queueStatus');
-const requestedByInput = document.getElementById('requestedByInput');
 const manualTitleInput = document.getElementById('vid1Title');
 const videoIdInput = document.getElementById('vid1');
 
-async function fetchQueue() {
-  if (!queueListEl || !queueStatusEl) {
-    return;
-  }
-  try {
-    queueStatusEl.textContent = 'Cargando la cola...';
-    const response = await fetch('/api/music/queue');
-    if (!response.ok) {
-      throw new Error(`Estado ${response.status}`);
-    }
-    const items = await response.json();
-    renderQueue(items);
-  } catch (error) {
-    console.error('Error al obtener la cola', error);
-    queueStatusEl.textContent = 'No se pudo cargar la cola.';
-    if (queueListEl) {
-      queueListEl.innerHTML = '';
-    }
-  }
+const queueManager = window.queueManager;
+if (!queueManager) {
+  throw new Error('queueManager no está disponible.');
 }
 
-function renderQueue(items) {
-  if (!queueListEl || !queueStatusEl) {
-    return;
-  }
-  queueListEl.innerHTML = '';
-  if (!Array.isArray(items) || items.length === 0) {
-    queueStatusEl.textContent = 'No hay canciones en cola.';
-    queueListEl.innerHTML = '<div class="rounded-2xl border border-dashed border-orange-200 bg-orange-50/50 px-5 py-6 text-center text-sm text-orange-500">La cola está vacía. Busca y selecciona videos para agregar.</div>';
-    return;
-  }
-  queueStatusEl.textContent = `Canciones en cola: ${items.length}`;
-  items.forEach((item, index) => {
-    const li = document.createElement('li');
-    li.className = 'group flex items-center gap-4 rounded-2xl border border-orange-100 bg-white/80 p-4 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-orange-100/50 animate-fade-in';
-    li.style.animationDelay = `${index * 100}ms`;
-
-    const thumb = document.createElement('img');
-    thumb.className = 'h-16 w-24 rounded-xl object-cover ring-1 ring-orange-100/60 group-hover:ring-orange-300 transition-all duration-300';
-    thumb.alt = '';
-    thumb.loading = 'lazy';
-    thumb.src = item.thumbnailUrl || (item.videoId ? `https://img.youtube.com/vi/${item.videoId}/mqdefault.jpg` : '');
-
-    const body = document.createElement('div');
-    body.className = 'flex-1 space-y-1';
-    
-    const title = document.createElement('div');
-    title.className = 'text-sm font-semibold text-slate-800 group-hover:text-orange-600 transition-colors duration-300 line-clamp-2';
-    title.textContent = item.title;
-    body.appendChild(title);
-
-    if (item.requestedBy) {
-      const meta = document.createElement('div');
-      meta.className = 'text-xs text-slate-500';
-      meta.innerHTML = `<span class="inline-flex items-center gap-1"><svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/></svg>Solicitada por ${item.requestedBy}</span>`;
-      body.appendChild(meta);
-    }
-
-    if (item.enqueuedAt) {
-      const metaTime = document.createElement('div');
-      metaTime.className = 'text-xs text-slate-400';
-      const parsed = new Date(item.enqueuedAt);
-      if (!isNaN(parsed)) {
-        metaTime.innerHTML = `<span class="inline-flex items-center gap-1"><svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"/></svg>${parsed.toLocaleString()}</span>`;
-        body.appendChild(metaTime);
-      }
-    }
-
-    li.appendChild(thumb);
-    li.appendChild(body);
-
-    queueListEl.appendChild(li);
-  });
-}
-
-async function enqueueSong(details) {
-  if (!details || !details.videoId || !details.title) {
-    throw new Error('Faltan datos obligatorios para la canciï¿½n.');
-  }
-  const payload = {
-    videoId: details.videoId,
-    title: details.title,
-    channelTitle: details.channelTitle ?? null,
-    thumbnailUrl: details.thumbnailUrl ?? null,
-    requestedBy: (requestedByInput?.value || '').trim() || null
-  };
-
-  const response = await fetch('/api/music/queue', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || 'No se pudo guardar la canciï¿½n.');
-  }
-
-  const item = await response.json();
-  await fetchQueue();
-  return item;
-}
-
-async function playOldestSongFromQueue() {
-  try {
-    const response = await fetch('/api/music/queue');
-    if (!response.ok) {
-      throw new Error(`Estado ${response.status}`);
-    }
-    const items = await response.json();
-    if (!Array.isArray(items) || items.length === 0) {
-      return false;
-    }
-    const nextItem = items[0];
-    if (!nextItem.videoId) {
-      return false;
-    }
-    currentQueueItemId = nextItem.id || null;
-    const startTimestamp = Date.now() + 1000;
-    await connection.invoke('LoadVideos', nextItem.videoId, startTimestamp, currentQueueItemId);
-    return true;
-  } catch (error) {
-    console.error('No se pudo iniciar la reproducción desde la cola', error);
-    return false;
-  }
-}
-
-async function removeQueueItemFromQueue(queueItemId) {
-  if (!queueItemId) {
-    return;
-  }
-  const response = await fetch(`/api/music/queue/${queueItemId}`, { method: 'DELETE' });
-  if (!response.ok && response.status !== 404) {
-    const message = await response.text();
-    throw new Error(message || `Estado ${response.status}`);
-  }
-}
-
-async function handleQueueSongEnded() {
-  if (isHandlingQueueEnd) {
-    return;
-  }
-  isHandlingQueueEnd = true;
-  try {
-    const finishedId = currentQueueItemId;
-    currentQueueItemId = null;
-    if (finishedId) {
-      try {
-        await removeQueueItemFromQueue(finishedId);
-      } catch (error) {
-        console.error('No se pudo eliminar la canción finalizada de la cola', error);
-      } finally {
-        fetchQueue();
-      }
-    } else {
-      fetchQueue();
-    }
-    const hasNext = await playOldestSongFromQueue();
-    if (!hasNext) {
-      connection.invoke('Pause');
-    }
-  } finally {
-    isHandlingQueueEnd = false;
-  }
-}
+const {
+  fetchQueue,
+  enqueueSong,
+  playOldestSongFromQueue,
+  removeQueueItemFromQueue,
+  handleQueueSongEnded,
+  setCurrentQueueItemId,
+  getCurrentQueueItemId,
+  clearCurrentQueueItem
+} = queueManager;
 
 // --- SignalR ---
 const connection = new signalR.HubConnectionBuilder()
@@ -194,7 +38,7 @@ fetchQueue();
 
 // Recibe eventos del hub
 connection.on("SyncState", (id1, startTimestamp, percent, isPlaying, queueItemId) => {
-  currentQueueItemId = queueItemId || null;
+  setCurrentQueueItemId(queueItemId || null);
   // Sincroniza el estado global al conectar
   isSyncing = true;
   playerReady = false;
@@ -237,7 +81,7 @@ connection.on("SeekPercent", (percent) => {
 });
 connection.on("LoadVideos", (id1, startTimestamp, queueItemId) => {
   isSyncing = true;
-  currentQueueItemId = queueItemId || null;
+  setCurrentQueueItemId(queueItemId || null);
   playerReady = false;
   playerA.loadVideoById({videoId: id1, startSeconds: 0});
   document.getElementById('vid1').value = id1;
@@ -495,8 +339,8 @@ window.radioApp = {
   setPercent,
   fetchQueue,
   removeQueueItemFromQueue,
-  getCurrentQueueItemId: () => currentQueueItemId,
-  clearCurrentQueueItem: () => { currentQueueItemId = null; },
+  getCurrentQueueItemId,
+  clearCurrentQueueItem,
   handleQueueSongEnded
 };
 

--- a/RadioQ10/wwwroot/js/queueManager.js
+++ b/RadioQ10/wwwroot/js/queueManager.js
@@ -1,0 +1,198 @@
+(function initializeQueueManager() {
+  const queueListEl = document.getElementById('queueList');
+  const queueStatusEl = document.getElementById('queueStatus');
+  const requestedByInput = document.getElementById('requestedByInput');
+
+  let currentQueueItemId = null;
+  let isHandlingQueueEnd = false;
+
+  async function fetchQueue() {
+    if (!queueListEl || !queueStatusEl) {
+      return;
+    }
+    try {
+      queueStatusEl.textContent = 'Cargando la cola...';
+      const response = await fetch('/api/music/queue');
+      if (!response.ok) {
+        throw new Error(`Estado ${response.status}`);
+      }
+      const items = await response.json();
+      renderQueue(items);
+    } catch (error) {
+      console.error('Error al obtener la cola', error);
+      queueStatusEl.textContent = 'No se pudo cargar la cola.';
+      if (queueListEl) {
+        queueListEl.innerHTML = '';
+      }
+    }
+  }
+
+  function renderQueue(items) {
+    if (!queueListEl || !queueStatusEl) {
+      return;
+    }
+    queueListEl.innerHTML = '';
+    if (!Array.isArray(items) || items.length === 0) {
+      queueStatusEl.textContent = 'No hay canciones en cola.';
+      queueListEl.innerHTML = '<div class="rounded-2xl border border-dashed border-orange-200 bg-orange-50/50 px-5 py-6 text-center text-sm text-orange-500">La cola está vacía. Busca y selecciona videos para agregar.</div>';
+      return;
+    }
+    queueStatusEl.textContent = `Canciones en cola: ${items.length}`;
+    items.forEach((item, index) => {
+      const li = document.createElement('li');
+      li.className = 'group flex items-center gap-4 rounded-2xl border border-orange-100 bg-white/80 p-4 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-orange-100/50 animate-fade-in';
+      li.style.animationDelay = `${index * 100}ms`;
+
+      const thumb = document.createElement('img');
+      thumb.className = 'h-16 w-24 rounded-xl object-cover ring-1 ring-orange-100/60 group-hover:ring-orange-300 transition-all duration-300';
+      thumb.alt = '';
+      thumb.loading = 'lazy';
+      thumb.src = item.thumbnailUrl || (item.videoId ? `https://img.youtube.com/vi/${item.videoId}/mqdefault.jpg` : '');
+
+      const body = document.createElement('div');
+      body.className = 'flex-1 space-y-1';
+
+      const title = document.createElement('div');
+      title.className = 'text-sm font-semibold text-slate-800 group-hover:text-orange-600 transition-colors duration-300 line-clamp-2';
+      title.textContent = item.title;
+      body.appendChild(title);
+
+      if (item.requestedBy) {
+        const meta = document.createElement('div');
+        meta.className = 'text-xs text-slate-500';
+        meta.innerHTML = `<span class="inline-flex items-center gap-1"><svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"/></svg>Solicitada por ${item.requestedBy}</span>`;
+        body.appendChild(meta);
+      }
+
+      if (item.enqueuedAt) {
+        const metaTime = document.createElement('div');
+        metaTime.className = 'text-xs text-slate-400';
+        const parsed = new Date(item.enqueuedAt);
+        if (!isNaN(parsed)) {
+          metaTime.innerHTML = `<span class="inline-flex items-center gap-1"><svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"/></svg>${parsed.toLocaleString()}</span>`;
+          body.appendChild(metaTime);
+        }
+      }
+
+      li.appendChild(thumb);
+      li.appendChild(body);
+
+      queueListEl.appendChild(li);
+    });
+  }
+
+  async function enqueueSong(details) {
+    if (!details || !details.videoId || !details.title) {
+      throw new Error('Faltan datos obligatorios para la canción.');
+    }
+    const payload = {
+      videoId: details.videoId,
+      title: details.title,
+      channelTitle: details.channelTitle ?? null,
+      thumbnailUrl: details.thumbnailUrl ?? null,
+      requestedBy: (requestedByInput?.value || '').trim() || null
+    };
+
+    const response = await fetch('/api/music/queue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'No se pudo guardar la canción.');
+    }
+
+    const item = await response.json();
+    await fetchQueue();
+    return item;
+  }
+
+  async function playOldestSongFromQueue() {
+    try {
+      const response = await fetch('/api/music/queue');
+      if (!response.ok) {
+        throw new Error(`Estado ${response.status}`);
+      }
+      const items = await response.json();
+      if (!Array.isArray(items) || items.length === 0) {
+        return false;
+      }
+      const nextItem = items[0];
+      if (!nextItem.videoId) {
+        return false;
+      }
+      currentQueueItemId = nextItem.id || null;
+      const startTimestamp = Date.now() + 1000;
+      await connection.invoke('LoadVideos', nextItem.videoId, startTimestamp, currentQueueItemId);
+      return true;
+    } catch (error) {
+      console.error('No se pudo iniciar la reproducción desde la cola', error);
+      return false;
+    }
+  }
+
+  async function removeQueueItemFromQueue(queueItemId) {
+    if (!queueItemId) {
+      return;
+    }
+    const response = await fetch(`/api/music/queue/${queueItemId}`, { method: 'DELETE' });
+    if (!response.ok && response.status !== 404) {
+      const message = await response.text();
+      throw new Error(message || `Estado ${response.status}`);
+    }
+  }
+
+  async function handleQueueSongEnded() {
+    if (isHandlingQueueEnd) {
+      return;
+    }
+    isHandlingQueueEnd = true;
+    try {
+      const finishedId = currentQueueItemId;
+      currentQueueItemId = null;
+      if (finishedId) {
+        try {
+          await removeQueueItemFromQueue(finishedId);
+        } catch (error) {
+          console.error('No se pudo eliminar la canción finalizada de la cola', error);
+        } finally {
+          fetchQueue();
+        }
+      } else {
+        fetchQueue();
+      }
+      const hasNext = await playOldestSongFromQueue();
+      if (!hasNext) {
+        connection.invoke('Pause');
+      }
+    } finally {
+      isHandlingQueueEnd = false;
+    }
+  }
+
+  function setCurrentQueueItemId(queueItemId) {
+    currentQueueItemId = queueItemId || null;
+  }
+
+  function getCurrentQueueItemId() {
+    return currentQueueItemId;
+  }
+
+  function clearCurrentQueueItem() {
+    currentQueueItemId = null;
+  }
+
+  window.queueManager = {
+    fetchQueue,
+    renderQueue,
+    enqueueSong,
+    playOldestSongFromQueue,
+    removeQueueItemFromQueue,
+    handleQueueSongEnded,
+    setCurrentQueueItemId,
+    getCurrentQueueItemId,
+    clearCurrentQueueItem
+  };
+})();


### PR DESCRIPTION
## Summary
- move queue CRUD operations from app.js into a new queueManager.js module
- update app.js to rely on the shared queue manager and expose queue helpers via radioApp
- register the new script in index.html so queue logic loads before app.js

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e26824494c8333aa8f90f870ca7f56