### PR TITLE
Require requester name when adding songs

### DIFF
--- a/RadioQ10/Domain/Entities/AddSongRequest.cs
+++ b/RadioQ10/Domain/Entities/AddSongRequest.cs
@@ -18,7 +18,8 @@ public sealed class AddSongRequest
     [Url]
     public string? ThumbnailUrl { get; set; }
 
+    [Required]
     [StringLength(64)]
-    public string? RequestedBy { get; set; }
+    public string RequestedBy { get; set; } = string.Empty;
 }
 


### PR DESCRIPTION
## Summary
- make the requester name required when adding a song to the queue

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27108d53083338c41fdca892c6eb9