### PR TITLE
Fix registration failures caused by HTTP-to-HTTPS redirect order

### DIFF
--- a/RadioQ10/Program.cs
+++ b/RadioQ10/Program.cs
@@ -43,8 +43,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseStaticFiles();
 app.UseHttpsRedirection();
+app.UseStaticFiles();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- ensure HTTPS redirection runs before serving static files so the frontend loads over HTTPS and API requests avoid redirect status codes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e29875eab08333863df3d74adcaf23