### PR TITLE
Add initial database migration for radio schema

### DIFF
--- a/RadioQ10/Infrastructure/Persistence/Migrations/20241011000000_InitialCreate.cs
+++ b/RadioQ10/Infrastructure/Persistence/Migrations/20241011000000_InitialCreate.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RadioQ10.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialCreate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "radio_users",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    IpAddress = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_radio_users", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "song_queue",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VideoId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ChannelTitle = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    ThumbnailUrl = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    RequestedBy = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    RequestedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    EnqueuedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_song_queue", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_song_queue_radio_users_RequestedByUserId",
+                        column: x => x.RequestedByUserId,
+                        principalTable: "radio_users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_radio_users_IpAddress_Name",
+                table: "radio_users",
+                columns: new[] { "IpAddress", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_song_queue_RequestedByUserId",
+                table: "song_queue",
+                column: "RequestedByUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "song_queue");
+
+            migrationBuilder.DropTable(
+                name: "radio_users");
+        }
+    }
+}

--- a/RadioQ10/Infrastructure/Persistence/Migrations/RadioDbContextModelSnapshot.cs
+++ b/RadioQ10/Infrastructure/Persistence/Migrations/RadioDbContextModelSnapshot.cs
@@ -1,0 +1,103 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using RadioQ10.Infrastructure.Persistence;
+
+#nullable disable
+
+namespace RadioQ10.Infrastructure.Persistence.Migrations
+{
+    [DbContext(typeof(RadioDbContext))]
+    partial class RadioDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.0-rc.2.24474.1");
+
+            modelBuilder.Entity("RadioQ10.Domain.Entities.RadioUser", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedNever()
+                    .HasColumnType("uuid");
+
+                b.Property<DateTimeOffset>("CreatedAt")
+                    .HasColumnType("timestamp with time zone");
+
+                b.Property<string>("IpAddress")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("character varying(64)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("character varying(64)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("IpAddress", "Name")
+                    .IsUnique();
+
+                b.ToTable("radio_users", (string)null);
+            });
+
+            modelBuilder.Entity("RadioQ10.Domain.Entities.SongQueueItem", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedNever()
+                    .HasColumnType("uuid");
+
+                b.Property<string>("ChannelTitle")
+                    .HasMaxLength(128)
+                    .HasColumnType("character varying(128)");
+
+                b.Property<DateTimeOffset>("EnqueuedAt")
+                    .HasColumnType("timestamp with time zone");
+
+                b.Property<string>("RequestedBy")
+                    .HasMaxLength(64)
+                    .HasColumnType("character varying(64)");
+
+                b.Property<Guid?>("RequestedByUserId")
+                    .HasColumnType("uuid");
+
+                b.Property<string>("ThumbnailUrl")
+                    .HasMaxLength(512)
+                    .HasColumnType("character varying(512)");
+
+                b.Property<string>("Title")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("character varying(256)");
+
+                b.Property<string>("VideoId")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("character varying(64)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("RequestedByUserId");
+
+                b.ToTable("song_queue", (string)null);
+            });
+
+            modelBuilder.Entity("RadioQ10.Domain.Entities.SongQueueItem", b =>
+            {
+                b.HasOne("RadioQ10.Domain.Entities.RadioUser", "RequestedByUser")
+                    .WithMany("RequestedSongs")
+                    .HasForeignKey("RequestedByUserId")
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                b.Navigation("RequestedByUser");
+            });
+
+            modelBuilder.Entity("RadioQ10.Domain.Entities.RadioUser", b =>
+            {
+                b.Navigation("RequestedSongs");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/RadioQ10/Program.cs
+++ b/RadioQ10/Program.cs
@@ -35,7 +35,7 @@ var app = builder.Build();
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<RadioDbContext>();
-    db.Database.EnsureCreated();
+    db.Database.Migrate();
 }
 if (app.Environment.IsDevelopment())
 {

--- a/RadioQ10/RadioQ10.csproj
+++ b/RadioQ10/RadioQ10.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-rc.2.24474.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-rc.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.5" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add Entity Framework Core design dependency required for migrations
- create the initial database migration that builds radio_users and song_queue tables with the requested user relationship
- migrate the database on application startup instead of using EnsureCreated

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2a0335b408333a3df97b838bb0a73