### PR TITLE
Remove redundant playback controls from control panel

### DIFF
--- a/RadioQ10/wwwroot/index.html
+++ b/RadioQ10/wwwroot/index.html
@@ -184,20 +184,6 @@
                                         <input id="requestedByInput" type="text" placeholder="Ingresa tu nombre para compartir canciones" class="w-full rounded-2xl border border-orange-200/70 bg-white/90 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-orange-400 focus:ring-2 focus:ring-orange-200" readonly />
                                     </label>
                                 </div>
-                                <div class="grid gap-3 sm:grid-cols-2">
-                                    <button id="playBtn" class="flex items-center justify-center rounded-2xl border border-orange-200/70 bg-white/90 px-4 py-3 text-sm font-semibold text-orange-600 transition hover:-translate-y-0.5 hover:shadow-lg hover:shadow-orange-100 focus:outline-none focus:ring-2 focus:ring-orange-200">Reproducir</button>
-                                    <button id="pauseBtn" class="flex items-center justify-center rounded-2xl border border-orange-200/70 bg-white/90 px-4 py-3 text-sm font-semibold text-orange-600 transition hover:-translate-y-0.5 hover:shadow-lg hover:shadow-orange-100 focus:outline-none focus:ring-2 focus:ring-orange-200">Pausar</button>
-                                </div>
-                                <div class="flex flex-col gap-3 rounded-2xl border border-dashed border-orange-200/70 bg-orange-50/70 p-4 sm:flex-row sm:items-end sm:justify-between">
-                                    <div class="flex flex-col gap-2 text-sm text-slate-600">
-                                        <span class="font-semibold text-orange-500">Ir a un punto especifico</span>
-                                        <span>Introduce un porcentaje entre 0 y 100 y haz clic en Ir.</span>
-                                    </div>
-                                    <div class="flex items-center gap-3">
-                                        <input id="percent" type="number" min="0" max="100" value="50" class="w-24 rounded-xl border border-orange-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-200" />
-                                        <button id="seekPercentBtn" class="rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-200">Ir</button>
-                                    </div>
-                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove the play, pause, and seek controls from the main control panel since the floating controls already provide those actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ed4924408333bf745561eba4ad3e