### PR TITLE
Fix static script references in index

### DIFF
--- a/RadioQ10/wwwroot/index.html
+++ b/RadioQ10/wwwroot/index.html
@@ -264,9 +264,9 @@
         </div>
     </div>
 
-    <script src="js/userManager.js"></script>
-    <script src="js/queueManager.js"></script>
-    <script src="js/app.js"></script>
-    <script src="js/buttonControls.js"></script>
+    <script src="/js/userManager.js" defer></script>
+    <script src="/js/queueManager.js" defer></script>
+    <script src="/js/app.js" defer></script>
+    <script src="/js/buttonControls.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point the front-end script tags at the root /js/ paths so the files resolve correctly
- defer the script loading so they execute after the DOM is parsed

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3baa815e08333a18b5c6cb52be73a